### PR TITLE
Updated AttachmentTimeline to check whether expected attachment is set.

### DIFF
--- a/spine-csharp/src/Animation.cs
+++ b/spine-csharp/src/Animation.cs
@@ -447,12 +447,20 @@ namespace Spine {
 				lastTime = -1;
 
 			int frameIndex = (time >= frames[frames.Length - 1] ? frames.Length : Animation.binarySearch(frames, time)) - 1;
-			if (frames[frameIndex] < lastTime) return;
-
-			String attachmentName = attachmentNames[frameIndex];
-			skeleton.slots[slotIndex].Attachment =
-				 attachmentName == null ? null : skeleton.GetAttachment(slotIndex, attachmentName);
+			Attachment expectedAttachment = GetExpectedAttachment(skeleton, frameIndex);
+			Attachment actualAttachment = skeleton.slots[this.slotIndex].attachment;
+			
+			if (frames[frameIndex] < lastTime && expectedAttachment == actualAttachment) 
+				return;
+			
+			skeleton.slots[slotIndex].Attachment = expectedAttachment;
 		}
+		
+		private Attachment GetExpectedAttachment(Skeleton skeleton, int frameIndex)
+	        {
+	            String attachmentName = attachmentNames[frameIndex];
+	            return attachmentName == null ? null : skeleton.GetAttachment(slotIndex, attachmentName);
+	        }
 	}
 
 	public class EventTimeline : Timeline {


### PR DESCRIPTION
Until now it was discarding the set of the attachment if lastTime is after keyTime. I'm having issues with this behavior when the skeleton is set to pose manually. After that, the attachment is the one used in setup intead of the expected one until the next keyframe.

For more information on the scenario. I'm using this to revert to pose only specific tracks. Doing the following.
1 -  Clear the Track To Revert
2 -  Revert Skeleton to pose
3 -  Update(0) this way the rest of the tracks apply to the skeleton again

I've made several characterization tests of this timeline before changing it, I can pass them to you if you want.
